### PR TITLE
Remove unnecessary mappings for invoicer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,9 +50,6 @@ services:
                 restart: on-failure
                 stop_grace_period: 30s
                 volumes:
-                        - "${PWD}/invoicer:/root/.lncm"
-                        - "${PWD}/invoicer:/data/.lncm"
-                        - "${PWD}/invoicer:/lncm"
                         - "${PWD}/invoicer:/data"
                         - "${PWD}/lnd:/lnd"
                 networks:

--- a/invoicer/invoicer.conf
+++ b/invoicer/invoicer.conf
@@ -1,8 +1,8 @@
 # Note: all values used in this file are defaults that are used if nothing is provided
 
 port = 8181
-static-dir = "/lncm/www/"
-log-file = "/lncm/invoicer.log"
+static-dir = "/data/www/"
+log-file = "/data/invoicer.log"
 ln-client = "lnd"
 
 off-chain-only = false


### PR DESCRIPTION
Tidy things up a little. Remove stuff that we don't (need) to use.

Because less is more.