### PR TITLE
Update bitcoind to 0.21.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
                     net:
                         ipv4_address: 10.254.1.2
         bitcoin:
-                image: lncm/bitcoind:v0.20.1
+                image: lncm/bitcoind:v0.21.0@sha256:32b3eb6d3599e7ae89c040d8c3fba4aac4f85ccca3bd0698bb45a790f9dbf2f1
                 container_name: bitcoin
                 volumes:
                         - ${PWD}/bitcoin:/root/.bitcoin


### PR DESCRIPTION
Some stuff in this release:

```
 - Descriptor wallets
 - Compact block filters over P2P network 
 - Fewer rebroadcast attempts
 - Tor V3 support
 - Schnorr/Taproot code
 ```

[Release notes (Courtesy of bitcoinmagazine)](https://bitcoinmagazine.com/articles/bitcoin-core-0-21-0-released-whats-new)

Now every bitcoin node can serve stuff over neutrino